### PR TITLE
Fix: var "task" cannot get par "command"

### DIFF
--- a/jd_identical.py
+++ b/jd_identical.py
@@ -65,7 +65,7 @@ def get_tasklist() -> list:
 def filter_res_sub(tasklist: list) -> tuple:
     filter_list = []
     res_list = []
-    for task in tasklist:
+    for task in tasklist.get("data"):
         for sub in sub_list:
             if task.get("command").find(sub) == -1:
                 flag = False


### PR DESCRIPTION
🐲青龙日志分析
📆分析 2023年01月16日23时 ~ 2023年01月16日00时 的日志报告：
✅正常运行脚本：452 次
⛔异常运行脚本：24 次，占比 5.31 %
🧐其中:
    🕵️‍♂️Nodejs异常：0 次，占比 0.0 %
    🕵️‍♂️Python异常：24 次，占比 5.31 %
💂‍♂️详细错误日志：

🛑脚本：shufflewzc_faker3_main_jd_identical_57：
- ⚠Python错误：AttributeError: 'str' object has no attribute 'get' 

在jd_identical.py 69 line: tasklist 内容为:`{'data':[{'id':162,'name':'xxx','command':'task repo/xxx.js'....},{'id':163,'name':'xxx','command':'task repo/xxx.js'....},]}`
需要先提取‘data’再提取’command‘




